### PR TITLE
Use env at call time

### DIFF
--- a/feather-config.js
+++ b/feather-config.js
@@ -30,7 +30,7 @@ exports.init = function(_options, cb) {
       appOptions = null,
       _breadcrumb = [];
 
-  if (defaultConfFile && path.existsSync(defaultConfFile)) {
+  if (defaultConfFile && fs.existsSync(defaultConfFile)) {
     defaultOptions = JSON.parse(fs.readFileSync(defaultConfFile, "utf-8"));
     _breadcrumb.push("Default options from " + defaultConfFile);
   }
@@ -40,7 +40,7 @@ exports.init = function(_options, cb) {
     _breadcrumb.push("Default hook used");
   }
 
-  if (path.existsSync(appConfFile)) {
+  if (fs.existsSync(appConfFile)) {
     appOptions = JSON.parse(fs.readFileSync(appConfFile, "utf-8"));
     _breadcrumb.push("App options from " + appConfFile);
   }
@@ -79,7 +79,7 @@ exports.init = function(_options, cb) {
       delete mergedOptions.environments;
       _breadcrumb.push("App config env " + mergedOptions.environment);
 
-    } else if (path.existsSync(appDir + "/conf/" + mergedOptions.useEnv + ".json")) { // See if there is a conf folder with a json file with that env name.
+    } else if (fs.existsSync(appDir + "/conf/" + mergedOptions.useEnv + ".json")) { // See if there is a conf folder with a json file with that env name.
       //console.info("\nUsing " + mergedOptions.useEnv + " environment from external file.");
       var filename = appDir + "/conf/" + mergedOptions.useEnv + ".json",
           envOptions = JSON.parse(fs.readFileSync(filename, "utf-8"));

--- a/feather-config.js
+++ b/feather-config.js
@@ -3,7 +3,7 @@ var path = require("path"),
     futil = require("./lib/util"),
     ns = require("./lib/ns");
 
-/* 
+/*
 
 ## Conventions used in this module
 
@@ -18,11 +18,11 @@ var path = require("path"),
 * defaultOptionsHook - function the defaultOptions are passed into in case the app wishes to augment them before proceeding.  This is called immediately after the default config file is read, and it _must_ be synchronous.
 * commandLineArgsHook - function to process individual command line arguments.  It _must_ be synchronous.
 
-*/ 
+*/
 exports.init = function(_options, cb) {
 
   _options = _options || {};
-  
+
   var appDir = _options.appDir || process.cwd(),
       defaultConfFile = _options.defaultConfigPath || null,
       appConfFile = _options.appConfigPath || (appDir + "/config.json"),
@@ -51,7 +51,11 @@ exports.init = function(_options, cb) {
     mergedOptions = futil.recursiveExtend(mergedOptions, appOptions);
   }
 
-  var cmdLineOptions = {}, 
+  if (_options.useEnv && !mergedOptions.useEnv) {
+    mergedOptions.useEnv = _options.useEnv;
+  }
+
+  var cmdLineOptions = {},
       i,
       argIndex = process.argv.indexOf(process.mainModule.filename) + 1;
   var cmdArgs = argIndex < process.argv.length ? process.argv.slice(argIndex) : process.argv,
@@ -67,7 +71,7 @@ exports.init = function(_options, cb) {
 
   // Resolve environmental use.
   var error = null;
-  if (mergedOptions.useEnv) { 
+  if (mergedOptions.useEnv) {
     if (mergedOptions.environments && mergedOptions.environments[mergedOptions.useEnv]) {
       //console.info("\nUsing " + mergedOptions.useEnv + " environment");
       mergedOptions.environment = mergedOptions.useEnv;
@@ -119,4 +123,3 @@ exports.init = function(_options, cb) {
 exports.safeGet = function(path, object) {
   return ns(path, object, true);
 };
-


### PR DESCRIPTION
Allows specifying `useEnv` at call time (enables programmatic config initialization scenarios) 

e.g.

```
featherConfig.init({useEnv: 'foo'}, ...)
```
